### PR TITLE
install obi's manpage

### DIFF
--- a/obi.rb
+++ b/obi.rb
@@ -61,6 +61,7 @@ class Obi < Formula
 
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+    man1.install "obi.1"
   end
 
   test do


### PR DESCRIPTION
This change installs the obi manpage when obi is installed through homebrew. https://github.com/Oblong/obi/pull/84