### PR TITLE
install obi completion script

### DIFF
--- a/obi.rb
+++ b/obi.rb
@@ -62,6 +62,9 @@ class Obi < Formula
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
     man1.install "obi.1"
+    if File.file? "obi-bash-completion.sh" then
+      bash_completion.install "obi-bash-completion.sh" => "obi"
+    end
   end
 
   test do


### PR DESCRIPTION
This alteration of the homebrew formula will install the bash command completion script added in this PR: https://github.com/Oblong/obi/pull/105